### PR TITLE
fix(Notebook): point to workspace directory as root directory

### DIFF
--- a/images/base/entrypoint.sh
+++ b/images/base/entrypoint.sh
@@ -24,7 +24,7 @@ show_help() {
 
 case "$command" in
 "notebook")
-  start-notebook.sh --ServerApp.root_dir=/home/jovyan/workspace
+  start-notebook.sh 
   ;;
 "singleuser")
   start-singleuser.sh

--- a/images/base/entrypoint.sh
+++ b/images/base/entrypoint.sh
@@ -24,7 +24,7 @@ show_help() {
 
 case "$command" in
 "notebook")
-  start-notebook.sh
+  start-notebook.sh --ServerApp.root_dir=/home/jovyan/workspace
   ;;
 "singleuser")
   start-singleuser.sh

--- a/images/base/jupyter_notebook_config.py
+++ b/images/base/jupyter_notebook_config.py
@@ -7,5 +7,7 @@ c.NotebookApp.tornado_settings = {
     "headers": {"Content-Security-Policy": os.environ["CONTENT_SECURITY_POLICY"]}
 }
 
+c.ServerApp.root_dir = "/home/jovyan/workspace"
+
 # https://github.com/jupyter-server/jupyter-resource-usage
 c.ResourceUseDisplay.track_cpu_percent = True


### PR DESCRIPTION
This PR changes the notebook behavior to move root directory to the workspace one. 

![Screenshot 2024-08-01 at 11 12 36](https://github.com/user-attachments/assets/d572fc08-3839-408f-8ddc-33ce61a9d4e6)
<img width="466" alt="Screenshot 2024-08-01 at 11 43 59" src="https://github.com/user-attachments/assets/85b1a028-8b71-46fe-a4ba-ef906ba92138">
