### PR TITLE
fix(Pipelines): print exception traceback

### DIFF
--- a/images/base/files/scripts/bootstrap_pipeline.py
+++ b/images/base/files/scripts/bootstrap_pipeline.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 import papermill as pm
@@ -131,4 +132,5 @@ if __name__ == "__main__":
         print("Pipeline completed.")
     except Exception as e:
         print(f"Pipeline failed: {e}", file=sys.stderr)
+        traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
We changed the SDK to only display the str of the error and not the trace. This PR allows to re-enable the display of the exception trace.