### PR TITLE
HEXA-1093 Allow to pass arguments when running notebook or singleuser

### DIFF
--- a/images/base/entrypoint.sh
+++ b/images/base/entrypoint.sh
@@ -24,10 +24,10 @@ show_help() {
 
 case "$command" in
 "notebook")
-  start-notebook.sh 
+  start-notebook.sh $arguments
   ;;
 "singleuser")
-  start-singleuser.sh
+  start-singleuser.sh $arguments
   ;;
 "pipeline")
   if [[ "$REMOTE_DEBUGGER" == "true" ]]; then


### PR DESCRIPTION
In the previous version, the arguments passed when running the container were not passed to the other scripts `start-notebook.sh` and `start-singleuser.sh`. It wasn't possible then from JupyterHub to pass arguments that could affect their configuration and behavior.

