### PR TITLE
Lighter base, add basic testing, fix GitHub action

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,13 +1,15 @@
 name: Build images
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
   release:
     types: [ published ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest-m
     steps:
       - name: Checkout
@@ -27,11 +29,62 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         # GITHUB_REF looks like "refs/tags/v0.3.1" - we need to extract the actual version without the v prefix
         run: echo "number=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install .
       
-      - name: Build and push "base" image
+      - name: Build and test "base" image
         uses: docker/build-push-action@v6
         with:
           load: true
+          push: false
+          context: images/base
+          tags: blsq/openhexa-base-environment:${{ steps.version.outputs.number || 'main' }}
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base
+      
+      - name: Test "base" image
+        run: |
+          pytest tests/ -v --docker-image blsq/openhexa-base-environment:${{ steps.version.outputs.number || 'main' }}
+      
+      - name: Build and test "blsq" image
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          push: false
+          context: images/blsq
+          tags: blsq/openhexa-blsq-environment:${{ steps.version.outputs.number || 'main' }}
+          cache-from: type=gha,scope=blsq
+          cache-to: type=gha,mode=max,scope=blsq
+      
+      - name: Test "blsq" image
+        run: |
+          pytest tests/ -v --docker-image blsq/openhexa-blsq-environment:${{ steps.version.outputs.number || 'main' }}
+      
+      - name: Build and test "blsq-r" image
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          push: false
+          context: images/blsq-r
+          tags: blsq/openhexa-blsq-r-environment:${{ steps.version.outputs.number || 'main' }}
+          cache-from: type=gha,scope=blsq-r
+          cache-to: type=gha,mode=max,scope=blsq-r
+      
+      - name: Test "blsq-r" image
+        run: |
+          pytest tests/ -v --docker-image blsq/openhexa-blsq-r-environment:${{ steps.version.outputs.number || 'main' }}
+
+      - name: Push images
+        if: success() && github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
           push: true
           context: images/base
           tags: |
@@ -39,8 +92,9 @@ jobs:
             blsq/openhexa-base-environment:latest
           cache-from: type=gha,scope=base
           cache-to: type=gha,mode=max,scope=base
-      
-      - name: Build and push "blsq" image
+
+      - name: Push "blsq" image
+        if: success() && github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           push: true
@@ -50,8 +104,9 @@ jobs:
             blsq/openhexa-blsq-environment:latest
           cache-from: type=gha,scope=blsq
           cache-to: type=gha,mode=max,scope=blsq
-      
-      - name: Build and push "blsq-r" image
+
+      - name: Push "blsq-r" image
+        if: success() && github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           push: true

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -17,6 +17,8 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
         
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -39,47 +41,34 @@ jobs:
         run: |
           pip install .
       
-      - name: Build and test "base" image
-        uses: docker/build-push-action@v6
-        with:
-          load: true
-          push: false
-          context: images/base
-          tags: blsq/openhexa-base-environment:${{ steps.version.outputs.number || 'main' }}
-          cache-from: type=gha,scope=base
-          cache-to: type=gha,mode=max,scope=base
-      
+      - name: Build base image
+        run: |
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=registry,ref=blsq/openhexa-base-environment:cache \
+            --cache-to type=registry,ref=blsq/openhexa-base-environment:cache,mode=max \
+            -t blsq/openhexa-base-environment:ci images/base --load
+    
       - name: Test "base" image
         run: |
-          pytest tests/ -v --docker-image blsq/openhexa-base-environment:${{ steps.version.outputs.number || 'main' }}
-      
-      - name: Build and test "blsq" image
-        uses: docker/build-push-action@v6
-        with:
-          load: true
-          push: false
-          context: images/blsq
-          tags: blsq/openhexa-blsq-environment:${{ steps.version.outputs.number || 'main' }}
-          cache-from: type=gha,scope=blsq
-          cache-to: type=gha,mode=max,scope=blsq
+          pytest tests/ -v --docker-image blsq/openhexa-base-environment:ci
+
+      - name: Build blsq image
+        run: |
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=registry,ref=blsq/openhexa-blsq-environment:cache \
+            --cache-to type=registry,ref=blsq/openhexa-blsq-environment:cache,mode=max \
+            -t blsq/openhexa-blsq-environment:ci images/blsq --build-arg BASE_IMAGE=blsq/openhexa-base-environment:ci --load
       
       - name: Test "blsq" image
         run: |
-          pytest tests/ -v --docker-image blsq/openhexa-blsq-environment:${{ steps.version.outputs.number || 'main' }}
+          pytest tests/ -v --docker-image blsq/openhexa-blsq-environment:ci
       
-      - name: Build and test "blsq-r" image
-        uses: docker/build-push-action@v6
-        with:
-          load: true
-          push: false
-          context: images/blsq-r
-          tags: blsq/openhexa-blsq-r-environment:${{ steps.version.outputs.number || 'main' }}
-          cache-from: type=gha,scope=blsq-r
-          cache-to: type=gha,mode=max,scope=blsq-r
-      
-      - name: Test "blsq-r" image
+      - name: Build blsq-r image
         run: |
-          pytest tests/ -v --docker-image blsq/openhexa-blsq-r-environment:${{ steps.version.outputs.number || 'main' }}
+          docker buildx build --platform linux/amd64 \
+            --cache-from type=registry,ref=blsq/openhexa-blsq-r-environment:cache \
+            --cache-to type=registry,ref=blsq/openhexa-blsq-r-environment:cache,mode=max \
+            -t blsq/openhexa-blsq-r-environment:ci images/blsq-r --build-arg BASE_IMAGE=blsq/openhexa-base-environment:ci --load
 
       - name: Push images
         if: success() && github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .pytest_cache
 build
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv
+.idea
+.pytest_cache
+build

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/datascience-notebook:2025-01-06
+FROM quay.io/jupyter/scipy-notebook:2025-03-23
 
 LABEL org.opencontainers.image.source=https://github.com/blsq/openhexa-docker-images
 LABEL org.opencontainers.image.description="OpenHEXA Jupyter Notebook image with additional tools and libraries"
@@ -6,19 +6,19 @@ LABEL org.opencontainers.image.licenses=MIT
 
 USER root
 
-
 # System libraries
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update && \ 
   # FUSE Amazon S3 
   apt-get install -y s3fs \
-  # ICU (for R)
-  libicu-dev \
-  # XML R library dependencies
-  libcurl4-openssl-dev libxml2-dev \
   # Fuse requirements
   gnupg lsb-release
+
+# Install Node.js 22.x
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean
 
 # FUSE Google Cloud Storage
 RUN gcsFuseRepo=gcsfuse-`lsb_release -c -s` && \
@@ -37,47 +37,33 @@ RUN locale-gen fr_FR fr_FR.UTF-8 es_ES es_ES.UTF-8 de_DE de_DE.UTF-8 && \
     update-locale
 
 # /home/hexa symlink (preferred path for data pipelines)
-RUN ln -s /home/jovyan /home/hexa
-RUN chown jovyan /home/hexa
-
-
-# Set environment variable for Conda cache directory inside the container
-ENV CONDA_PKGS_DIRS=/opt/conda/pkgs
-
-RUN conda uninstall r-base && conda install --yes  -c conda-forge -c R -c blsqtech -c bioconda \
-  'r-base=4.4.*' \
-  # This package is included in other libraries and one (don't know which one) is requesting the version '*.*'.
-  # This is not compatible with the libmamba resolver of Conda and make next conda install to fail.
-  'blas=2.131' \
-  'r-irkernel=1.3.*' \
-  'nodejs=22.12.*' \
-  'fsspec=2023.12.2' \
-  'gcsfs=2023.12.2' \
-  'papermill=2.6.*' \
-  # Install openhexa-sdk & openhexa-toolbox from anaconda
-  'openhexa.sdk=2.*' \
-  'openhexa.toolbox=1.*' \
-  # Jupyter extensions
-  'jupyterlab-git=0.*' \
-  'jupyter-resource-usage=1.*' \
-  'jupyterlab_code_formatter=2.*' && \
-  conda clean --all -y
+RUN ln -s /home/jovyan /home/hexa && \
+  chown jovyan /home/hexa
 
 USER ${NB_UID}
 
+RUN mamba install --yes  -c conda-forge -c blsqtech  \
+  # This package is included in other libraries and one (don't know which one) is requesting the version '*.*'.
+  # This is not compatible with the libmamba resolver of Conda and make next conda install to fail.
+  'blas=2.131' \
+  'fsspec>=2025,<2026' \
+  'gcsfs>=2025,<2026' \
+  'papermill>=2.6,<2.7' \
+  # Install openhexa-sdk & openhexa-toolbox from anaconda
+  'openhexa.sdk>=2,<3' \
+  'openhexa.toolbox>=1,<2' \
+  # Jupyter extensions
+  'jupyter-resource-usage' \
+  'jupyterlab_code_formatter' && \
+  conda clean --all -y && \
+  fix-permissions "${CONDA_DIR}"
 
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Build Jupyterlab - needed for extensions
-RUN jupyter lab build -y --dev-build=False && \
-  jupyter lab clean -y && \
-  npm cache clean --force && \
-  rm -rf "/home/${NB_USER}/.cache/yarn"
 
 # custom config
 COPY jupyter_notebook_config.py /etc/jupyter/
 
-# Install openhexa-sdk & openhexa-toolbox
-ENV HEXA_ENVIRONMENT CLOUD_JUPYTER
+ENV HEXA_ENVIRONMENT=CLOUD_JUPYTER
 
 
 # s3f fuse
@@ -87,7 +73,6 @@ COPY files/scripts/* /tmp/hexa_scripts/
 # Please note that if a PVC is mounted at /home/jovyan (for OpenHEXA legacy notebooks), this directory will be
 # "lost" - they need to be copied again from /tmp after mounting the PVC
 COPY files/scripts/* /home/jovyan/.hexa_scripts/
-
 # sample files
 COPY files/sample_files/* /home/jovyan
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -56,8 +56,7 @@ RUN mamba install --yes  -c conda-forge -c blsqtech  \
   'jupyter-resource-usage' \
   'jupyterlab_code_formatter' && \
   conda clean --all -f -y && \
-  fix-permissions "${CONDA_DIR}" && \
-  fix-permissions /home/jovyan
+  fix-permissions "${CONDA_DIR}"
 
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -55,8 +55,9 @@ RUN mamba install --yes  -c conda-forge -c blsqtech  \
   # Jupyter extensions
   'jupyter-resource-usage' \
   'jupyterlab_code_formatter' && \
-  conda clean --all -y && \
-  fix-permissions "${CONDA_DIR}"
+  conda clean --all -f -y && \
+  fix-permissions "${CONDA_DIR}" && \
+  fix-permissions /home/jovyan
 
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 

--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -1,4 +1,6 @@
-FROM blsq/openhexa-base-environment
+ARG BASE_IMAGE=blsq/openhexa-base-environment
+
+FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.source=https://github.com/blsq/openhexa-docker-images
 LABEL org.opencontainers.image.description="OpenHEXA Jupyter Notebook image with additional tools and libraries for R oriented projects."
@@ -21,6 +23,7 @@ RUN wget https://quarto.org/download/latest/quarto-linux-amd64.deb \
     && dpkg -i quarto-linux-amd64.deb \
     && rm quarto-linux-amd64.deb
 
+USER ${NB_UID}
 RUN conda install --yes -c R -c conda-forge \
     r-tidyverse \
     r-arrow=18.1.* \
@@ -111,7 +114,8 @@ RUN conda install --yes -c R -c conda-forge \
     r-askpass=1.2.1 \
     r-ragg=1.3 \
     r-textshaping=0.4.0 \
-    && conda clean --all -y
+    && conda clean --all -y && \
+    fix-permissions "${CONDA_DIR}"
 
 
 # R packages (only available on cran)

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -1,14 +1,13 @@
-FROM blsq/openhexa-base-environment
+ARG BASE_IMAGE=blsq/openhexa-base-environment
 
-LABEL org.opencontainers.image.source=https://github.com/blsq/openhexa-docker-images
-LABEL org.opencontainers.image.description="OpenHEXA Jupyter Notebook image with additional tools and libraries specific to BLSQ use cases."
-LABEL org.opencontainers.image.licenses=MIT
+FROM ${BASE_IMAGE}
 
 USER root
 
 # System libraries
 RUN apt-get update && apt-get install -y libgdal-dev libudunits2-dev
 
+USER ${NB_UID}
 # Install additional Python and R packages
 RUN conda install --yes  -c conda-forge -c R \
   # Python packages
@@ -43,7 +42,10 @@ RUN conda install --yes  -c conda-forge -c R \
   'contextily=1.*' \
   'tabpy=2.*' \
   'docxtpl=0.11.*' \
+  # R : We setup a minimal R environment to be able to use this image as a base for the workspaces
+  'r-base=4.4.*' \
   # R Packages
+  'r-irkernel=1.3.*' \
   'r-arrow=18.1.*' \
   'r-getpass=0.*' \
   'r-readxl=1.*' \
@@ -62,12 +64,13 @@ RUN conda install --yes  -c conda-forge -c R \
   'r-raster=3.*' \
   'r-sf=1.*' \
   'r-stringi=1.*' \
-  && conda clean --all -y
+  && conda clean --all -y && \
+  fix-permissions "${CONDA_DIR}"
 
   
 # R packages (only available on cran)
 RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools', 'OpenStreetMap'), dependencies=TRUE, quiet=TRUE, repos='https://cran.r-project.org/', Ncpus=parallel::detectCores())"
-  
+
 USER ${NB_UID}
 WORKDIR $HOME
 

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -8,6 +8,8 @@ USER root
 RUN apt-get update && apt-get install -y libgdal-dev libudunits2-dev
 
 USER ${NB_UID}
+
+RUN ls -la /home/jovyan
 # Install additional Python and R packages
 RUN conda install --yes  -c conda-forge -c R \
   # Python packages
@@ -65,8 +67,7 @@ RUN conda install --yes  -c conda-forge -c R \
   'r-sf=1.*' \
   'r-stringi=1.*' \
   && conda clean --all -f -y && \
-  fix-permissions "${CONDA_DIR}" && \
-  fix-permissions /home/jovyan
+  fix-permissions "${CONDA_DIR}"
 
 # R packages (only available on cran)
 RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools', 'OpenStreetMap'), dependencies=TRUE, quiet=TRUE, repos='https://cran.r-project.org/', Ncpus=parallel::detectCores())"

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -64,14 +64,13 @@ RUN conda install --yes  -c conda-forge -c R \
   'r-raster=3.*' \
   'r-sf=1.*' \
   'r-stringi=1.*' \
-  && conda clean --all -y && \
-  fix-permissions "${CONDA_DIR}"
+  && conda clean --all -f -y && \
+  fix-permissions "${CONDA_DIR}" && \
+  fix-permissions /home/jovyan
 
-  
 # R packages (only available on cran)
 RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools', 'OpenStreetMap'), dependencies=TRUE, quiet=TRUE, repos='https://cran.r-project.org/', Ncpus=parallel::detectCores())"
 
-USER ${NB_UID}
 WORKDIR $HOME
 
 # Set PYTHONUNBUFFERED to ensure that Python output is sent straight to terminal

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -33,7 +33,7 @@ RUN conda install --yes  -c conda-forge -c R \
   'lxml=5.*' \
   'nbresuse=0.4.*' \
   'netCDF4=1.*' \
-  'polars=0.20.*' \
+  'polars=1.26.*' \
   'psycopg2=2.*' \
   'pyarrow=18.1.*' \
   'rapidfuzz=3.*' \

--- a/images/sonder/Dockerfile
+++ b/images/sonder/Dockerfile
@@ -10,6 +10,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 USER ${NB_UID}
 WORKDIR $HOME
 RUN conda install --yes -c conda-forge \
+  'r-base' \
+  'r-irkernel=1.3.*' \
   'r-rpostgres=1.4.*' \
   'r-reticulate=1.40.*'\
   'r-rcolorbrewer=1.*'  \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openhexa-docker-images"
+version = "1.8.0"
+description = "Docker images for OpenHexa"
+requires-python = ">=3.12"
+dependencies = [
+    "pytest>=7.4.0",
+    "docker",
+    "colorist==1.8.3"
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+addopts = "-v -s" 
+

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
+  "release-type": "python",
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,34 @@
+# Testing
+
+This directory contains tests for the OpenHexa Docker images.
+
+## Setup
+
+1. Create a virtual environment (recommended):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Unix/macOS
+   # or
+   .\venv\Scripts\activate  # On Windows
+   ```
+
+2. Install dependencies:
+   ```bash
+   pip install -e .
+   ```
+
+## Running Tests
+
+To run all tests:
+```bash
+pytest
+```
+
+To run specific test files:
+```bash
+pytest tests/test_*.py
+```
+
+## Test Structure
+
+- `test_*.py`: Test files for various components

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--docker-image",
+        action="store",
+        default=None,
+        help="Docker image to use for testing. If not specified, all configured images will be tested.",
+    )
+
+
+@pytest.fixture
+def docker_image(request):
+    """Fixture that returns the docker image specified via command line or None."""
+    docker_image = request.config.getoption("--docker-image")
+    if docker_image is None:
+        pytest.fail("Docker image not specified")
+    return docker_image

--- a/tests/pipelines/multiply_by_two/pipeline.py
+++ b/tests/pipelines/multiply_by_two/pipeline.py
@@ -1,0 +1,30 @@
+"""Template for newly generated pipelines."""
+
+from openhexa.sdk import current_run, parameter, pipeline
+
+
+@pipeline("multiply_by_two")
+@parameter("number", type=int, default=42)
+def multiply_by_two(number: int):
+    """Write your pipeline orchestration here.
+
+    Pipeline functions should only call tasks and should never perform IO operations or expensive computations.
+    """
+    result = task_1(number)
+    task_2(number, result)
+
+
+@multiply_by_two.task
+def task_1(number: int):
+    current_run.log_info("Multiplying by two...")
+
+    return number * 2
+
+
+@multiply_by_two.task
+def task_2(number: int, result: int):
+    current_run.log_info(f"{number} * 2 = {result}")
+
+
+if __name__ == "__main__":
+    multiply_by_two()

--- a/tests/pipelines/multiply_by_two/workspace.yaml
+++ b/tests/pipelines/multiply_by_two/workspace.yaml
@@ -1,0 +1,8 @@
+database:
+  host: localhost
+  username: some_username
+  password: some_password
+  dbname: the_db_name
+  port: 5432
+files:
+  path: ./workspace

--- a/tests/test_local_pipelines.py
+++ b/tests/test_local_pipelines.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from tests.testutils import run_local_pipeline
+
+# Get the pipelines directory
+pipelines_dir = Path(__file__).parent / "pipelines"
+
+
+def test_multiply_by_two_success(docker_image):
+    logs = run_local_pipeline(docker_image, pipelines_dir / "multiply_by_two")
+
+    assert "Multiplying by two..." in logs
+    assert "42 * 2 = 84" in logs
+
+    logs = run_local_pipeline(
+        docker_image, pipelines_dir / "multiply_by_two", config={"number": 43}
+    )
+    assert "Multiplying by two..." in logs
+    assert "43 * 2 = 86" in logs

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,3 @@
+def test_pytest_setup():
+    """Verify that pytest is working correctly."""
+    assert True

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,41 @@
+import base64
+import json
+from pathlib import Path
+
+import docker
+from colorist import effect_dim, effect_underline
+
+
+def run_local_pipeline(
+    docker_image: str,
+    pipeline_dir: Path,
+    environment: dict[str, str] = {},
+    config: dict[str, str] = {},
+):
+    client = docker.from_env()
+    try:
+        command = ["pipeline", "run"]
+        if config:
+            command.append("--config")
+            command.append(
+                base64.b64encode(json.dumps(config).encode("utf-8")).decode("utf-8")
+            )
+
+        logs = client.containers.run(
+            docker_image,
+            command=command,
+            volumes={pipeline_dir: {"bind": "/home/hexa/pipeline"}},
+            environment={"HEXA_ENVIRONMENT": "LOCAL_PIPELINE", **environment},
+            stdout=True,
+            stderr=True,
+        )
+        logs = logs.decode("utf-8")
+
+        # Print logs to console in gray color
+        print("\n")
+        effect_underline("Pipeline logs")
+        effect_dim(logs)
+
+        return logs
+    finally:
+        client.close()


### PR DESCRIPTION
- The base image is way lighter and comes as the foundation for all the custom workspace images
- A basic pipeline and a testing mechanism has been implemented (but needs to be refined and improved)
- The GitHub Action is now using raw commands to build images. I noticed that the GitHub action tend to use the base image from the registry instead of the local one. I lost a lot of time on this.