### PR TITLE
feat: set PROJ_LIB env variable

### DIFF
--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -125,3 +125,6 @@ RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools
 
 USER ${NB_UID}
 WORKDIR $HOME
+
+# Set PROJ_LIB env variable needed by the R sf package
+ENV PROJ_LIB=/opt/conda/share/proj

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -78,3 +78,5 @@ WORKDIR $HOME
 ENV PYTHONUNBUFFERED=1
 # Set RUFF_CACHE_DIR env variable
 ENV RUFF_CACHE_DIR=/tmp/.ruff_cache
+# Set PROJ_LIB env variable needed by the R sf package
+ENV PROJ_LIB=/opt/conda/share/proj


### PR DESCRIPTION
Set `PROJ_LIB` env variable which seem to be required by the `r-sf` package. This should be set by the conda package when activating the conda environment, but it doesn't seem to be the case. Only `PROJ_DATA` is set by the `proj` conda package.

See message from @sPuntinG https://bluesquare.slack.com/archives/C0288HL2P7C/p1752594557279099