### PR TITLE
chore: Move psycopg2 dependency to base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -57,6 +57,7 @@ RUN mamba install --yes  -c conda-forge -c blsqtech  \
   'fsspec>=2025,<2026' \
   'gcsfs>=2025,<2026' \
   'papermill>=2.6,<2.7' \
+  'psycopg2-binary=2.*' \
   # Install openhexa-sdk & openhexa-toolbox from anaconda \
   'bioconda::epiweeks' \
   'openhexa.sdk=2.12.2' \

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -36,7 +36,6 @@ RUN conda install --yes  -c conda-forge -c R \
   'nbresuse=0.4.*' \
   'netCDF4=1.*' \
   'polars=1.26.*' \
-  'psycopg2=2.*' \
   'pyarrow=18.1.*' \
   'rapidfuzz=3.*' \
   'xarray=2025.1.1' \


### PR DESCRIPTION
conda-forge doesn't include the binaries anymore so let's it explicitly.