### PR TITLE
fix: Out of memory when building blsq-r image (2nd try) (HEXA-1684)

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -77,6 +77,9 @@ jobs:
           tags: localhost:5000/openhexa-blsq-r-environment
           build-args: BASE_IMAGE=localhost:5000/openhexa-base-environment
 
+      - name: Test blsq-r image
+        run: pytest tests/ -v --docker-image localhost:5000/openhexa-blsq-r-environment
+
       - name: Push images to DockerHub
         if: github.event_name == 'push' || github.event_name == 'release'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .venv
+venv
 .idea
 .pytest_cache
 build
 __pycache__
+*.egg-info/
 
 # AI Coworkers
 /.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## What this repo is
+
+A collection of Docker images for OpenHexa workspaces (notebooks and pipelines).
+There are three images, layered:
+
+- `images/base` — the base environment.
+- `images/blsq` — built on top of base (`--build-arg BASE_IMAGE=...`).
+- `images/blsq-r` — built on top of base, adds R.
+
+## Rules
+
+- **Never commit to git.** Do not run `git commit`, `git push`, `git tag`, or
+  any other command that writes to git history. Committing is a human
+  responsibility. Make and stage changes if asked, but leave the actual commit
+  to a person.
+
+## Build & test
+
+The `Makefile` mirrors the CI checks in `.github/workflows/build_image.yml` and
+runs them against the local Docker daemon.
+
+Create and activate a Python virtual environment before running any `make`
+commands, so test dependencies install into an isolated environment rather than
+your system Python:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+```
+
+```bash
+make deps    # install Python test dependencies
+make build   # build all three images (alias: make b)
+make test    # test all three images (alias: make t)
+make ci      # full pipeline: build + test base, blsq, blsq-r
+```
+
+Single-image targets are also available, e.g. `make build-base`, `make test-blsq`.
+
+Tests live in `tests/` and run via pytest against a built image:
+
+```bash
+python -m pytest tests/ -v --docker-image openhexa-base-environment
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Makefile for building and testing the OpenHexa Docker images locally.
+#
+# This mirrors the checks in .github/workflows/build_image.yml, but runs them
+# against your local Docker daemon. Because `docker build` writes directly to
+# the local daemon, the dependent images (blsq, blsq-r) can reference the
+# freshly built base image by tag — no local registry is needed like in CI.
+#
+# Common usage:
+#   make ci          # full pipeline: build + test base, blsq, blsq-r
+#   make build       # build all three images (alias: make b)
+#   make test        # test all three images (alias: make t)
+#   make build-base  # build a single image
+#   make test-base   # test a single image
+#   make deps        # install the Python test dependencies
+
+BASE_IMAGE   ?= openhexa-base-environment
+BLSQ_IMAGE   ?= openhexa-blsq-environment
+BLSQ_R_IMAGE ?= openhexa-blsq-r-environment
+PLATFORM     ?= linux/amd64
+
+# docker-py ignores Docker CLI contexts, so pin both build and tests to the active endpoint.
+ifeq ($(strip $(DOCKER_HOST)),)
+DOCKER_HOST := $(shell docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)
+endif
+export DOCKER_HOST
+
+DOCKER_BUILD := docker build --platform $(PLATFORM)
+PYTEST       := python -m pytest tests/ -v
+
+## Build
+
+build-base:
+	@echo "Building the base image"
+	$(DOCKER_BUILD) -t $(BASE_IMAGE) images/base
+
+build-blsq: build-base
+	@echo "Building the blsq image"
+	$(DOCKER_BUILD) --build-arg BASE_IMAGE=$(BASE_IMAGE) -t $(BLSQ_IMAGE) images/blsq
+
+build-blsq-r: build-base
+	@echo "Building the blsq-r image"
+	$(DOCKER_BUILD) --build-arg BASE_IMAGE=$(BASE_IMAGE) -t $(BLSQ_R_IMAGE) images/blsq-r
+
+b build: build-base build-blsq build-blsq-r
+
+## Test
+
+test-base:
+	@echo "Testing the base image"
+	$(PYTEST) --docker-image $(BASE_IMAGE)
+
+test-blsq:
+	@echo "Testing the blsq image"
+	$(PYTEST) --docker-image $(BLSQ_IMAGE)
+
+test-blsq-r:
+	@echo "Testing the blsq-r image"
+	$(PYTEST) --docker-image $(BLSQ_R_IMAGE)
+
+t test: test-base test-blsq test-blsq-r
+
+## Misc
+
+deps:
+	@echo "Installing test dependencies"
+	pip install .
+
+ci: build-base test-base build-blsq test-blsq build-blsq-r test-blsq-r

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -59,8 +59,8 @@ RUN mamba install --yes  -c conda-forge -c blsqtech  \
   'duckdb>=1.3,<1.5' \
   # Install openhexa-sdk & openhexa-toolbox from anaconda \
   'bioconda::epiweeks' \
-  'openhexa.sdk=2.20.0' \
-  'openhexa.toolbox=2.10.0' \
+  'openhexa.sdk=2.21.0' \
+  'openhexa.toolbox=2.11.0' \
   # Jupyter extensions
   'jupyter-resource-usage' \
   'jupyterlab_code_formatter' && \

--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -24,98 +24,54 @@ RUN wget https://quarto.org/download/latest/quarto-linux-amd64.deb \
     && rm quarto-linux-amd64.deb
 
 USER ${NB_UID}
+
+# R 4.5+ on conda-forge is built against icu 78, which matches this image's base
+# Python stack (pyarrow, libmamba/conda).
 RUN mamba install --yes -c conda-forge \
-    r-arrow=18.1.* \
-    r-irkernel=1.3.* \
+    r-base=4.5.* \
+    r-irkernel \
+    # r-irkernel also pulls in: r-crayon r-digest
+    r-arrow \
     r-tidyverse \
-    r-arrow=18.1.* \
-    r-getpass=0.* \
-    r-readxl=1.* \
-    r-rcolorbrewer=1.* \
-    r-rjson=0.2.* \
-    r-rpostgres=1.4.* \
-    r-styler=1.* \
-    r-viridis=0.6.* \
-    r-nloptr=2.* \
-    r-rgeos=0.* \
-    r-rgooglemaps=1.5.* \
-    r-ggmap=4.0.* \
-    r-ggthemes=5.1.* \
-    r-maptools=1.* \
-    r-plotly=4.* \
-    r-raster=3.* \
-    r-sf=1.* \
-    r-stringi=1.* \
-    r-glue=1.7 \
-    r-here=1.0 \
-    r-lubridate=1.9 \
-    r-forcats=1.0 \
-    r-stringr=1.5 \
-    r-dplyr=1.1 \
-    r-purrr=1.0 \
-    r-readr=2.1 \
-    r-tidyr=1.3 \
-    r-tibble=3.2 \
-    r-ggplot2=3.5 \
-    r-gtable=0.3 \
-    r-websocket=1.4 \
-    r-processx=3.8 \
-    r-tzdb=0.4 \
-    r-ps=1.7 \
-    r-vctrs=0.6 \
-    r-generics=0.1 \
-    r-proxy=0.4 \
-    r-fansi=1.0 \
-    r-pkgconfig=2.0 \
-    r-kernsmooth=2.23 \
-    r-lifecycle=1.0 \
-    r-farver=2.1 \
-    r-munsell=0.5 \
-    r-httpuv=1.6 \
-    r-sass=0.4 \
-    r-htmltools=0.5 \
-    r-rttf2pt1=1.3 \
-    r-later=1.3 \
-    r-pillar=1.9 \
-    r-crayon=1.5 \
-    r-classint=0.4 \
-    r-mime=0.12 \
-    r-tidyselect=1.2 \
-    r-digest=0.6 \
-    r-stringi=1.8 \
-    r-labeling=0.4 \
-    r-rprojroot=2.0 \
-    r-fastmap=1.2 \
-    r-colorspace=2.1 \
-    r-cli=3.6 \
-    r-magrittr=2.0 \
-    r-utf8=1.2 \
-    r-rlang=1.1 \
-    r-rcpp=1.0 \
-    r-dbi=1.2 \
-    r-xml=3 \
-    r-xml2=1.3 \
-    r-renv=1.0 \
-    r-jsonlite=1.8 \
-    r-rstudioapi=0.16 \
-    r-e1071=1.7 \
-    r-withr=3.0 \
-    r-promises=1.3 \
-    r-scales=1.3 \
-    r-bit64=4.0 \
-    r-timechange=0.3 \
-    r-bit=4.0 \
-    r-qpdf=1.3 \
-    r-hms=1.1 \
-    r-pagedown=0.20 \
-    r-vroom=1.6 \
-    r-r6=2.5 \
-    r-fs=1.6 \
-    r-systemfonts=1.1 \
-    r-units=0.8 \
-    r-askpass=1.2.1 \
-    r-ragg=1.3 \
-    r-textshaping=0.4.0 \
+    # r-tidyverse also pulls in: r-dplyr r-stringr r-glue r-lubridate r-forcats
+    #   r-purrr r-readr r-tidyr r-tibble r-ggplot2 r-readxl r-magrittr r-jsonlite
+    #   r-rlang r-cli r-pillar r-hms r-rstudioapi r-xml2 r-ragg r-stringi r-vctrs
+    #   r-generics r-tidyselect r-lifecycle r-pkgconfig r-fansi r-utf8 r-r6
+    #   r-withr r-scales r-farver r-labeling r-munsell r-colorspace r-gtable
+    #   r-tzdb r-vroom r-bit64 r-bit r-timechange r-fs r-systemfonts r-textshaping
+    #   r-askpass
+    r-getpass \
+    r-rcolorbrewer \
+    r-rjson \
+    r-rpostgres \
+    # r-rpostgres also pulls in: r-dbi
+    r-styler \
+    r-viridis \
+    r-nloptr \
+    r-rgooglemaps \
+    r-ggmap \
+    r-ggthemes \
+    r-plotly \
+    # r-plotly also pulls in: r-htmltools r-promises r-later r-fastmap r-mime
+    r-raster \
+    # r-raster also pulls in: r-rcpp
+    r-sf \
+    # r-sf also pulls in: r-classint r-units
+    r-here \
+    # r-here also pulls in: r-rprojroot
+    r-websocket \
+    r-processx \
+    r-ps \
+    r-kernsmooth \
+    r-httpuv \
+    r-sass \
+    r-rttf2pt1 \
+    r-xml \
+    r-renv \
+    r-e1071 \
+    # r-e1071 also pulls in: r-proxy
+    r-qpdf \
+    r-pagedown \
     && mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}"
 

--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -10,7 +10,7 @@ USER root
 
 # System libraries
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
@@ -73,12 +73,15 @@ RUN mamba install --yes -c conda-forge \
     r-qpdf \
     r-pagedown \
     r-httr \
+    r-reticulate \
+    r-fpp3 \
+    r-survey \
     && mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}"
 
 
 # R packages (only available on cran)
-RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools', 'OpenStreetMap'), dependencies=TRUE, quiet=TRUE, repos='https://cran.r-project.org/', Ncpus=parallel::detectCores())"
+RUN R -e "options(Ncpus = parallel::detectCores()); install.packages(c('GISTools', 'OpenStreetMap', 'DHS.rates'), dependencies=TRUE, quiet=TRUE, repos='https://cran.r-project.org/', Ncpus=parallel::detectCores())"
 
 USER ${NB_UID}
 WORKDIR $HOME

--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -72,6 +72,7 @@ RUN mamba install --yes -c conda-forge \
     # r-e1071 also pulls in: r-proxy
     r-qpdf \
     r-pagedown \
+    r-httr \
     && mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}"
 

--- a/images/blsq-r/Dockerfile
+++ b/images/blsq-r/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://quarto.org/download/latest/quarto-linux-amd64.deb \
     && rm quarto-linux-amd64.deb
 
 USER ${NB_UID}
-RUN conda install --yes -c conda-forge \
+RUN mamba install --yes -c conda-forge \
     r-arrow=18.1.* \
     r-irkernel=1.3.* \
     r-tidyverse \
@@ -116,7 +116,7 @@ RUN conda install --yes -c conda-forge \
     r-askpass=1.2.1 \
     r-ragg=1.3 \
     r-textshaping=0.4.0 \
-    && conda clean --all -y && \
+    && mamba clean --all -f -y && \
     fix-permissions "${CONDA_DIR}"
 
 

--- a/images/blsq/Dockerfile
+++ b/images/blsq/Dockerfile
@@ -17,6 +17,8 @@ RUN ls -la /home/jovyan
 # Split into batches to avoid running out of memory.
 RUN mamba install --yes -c conda-forge \
     # Python packages
+    # Pin sqlite: geo stack otherwise drags in the old monolithic 3.32.3, breaking import sqlite3.
+    'sqlite>=3.49' \
     'ruff' \
     'boto3' \
     'python-kaleido' \
@@ -49,6 +51,8 @@ RUN mamba install --yes -c conda-forge \
     'docxtpl' \
     'pyodbc' \
   && mamba install --yes -c conda-forge -c R \
+    # Pin sqlite here too: the R batch re-downgrades it to 3.32.3 within this same layer.
+    'sqlite>=3.49' \
     # R : We setup a minimal R environment to be able to use this image as a base for the workspaces
     'r-base=4.4.*' \
     # R Packages

--- a/tests/pipelines/fiona_import/pipeline.py
+++ b/tests/pipelines/fiona_import/pipeline.py
@@ -1,0 +1,35 @@
+"""Regression test: importing `fiona` must not crash on a libgdal/libsqlite3 symbol mismatch.
+
+    File ".../fiona/__init__.py", line 42, in <module>
+        from fiona._env import (
+    ...
+    ImportError: .../fiona/../../../libgdal.so.36:
+        undefined symbol: sqlite3_total_changes64
+
+The conda libgdal.so.36 was linked against a newer libsqlite3 than the one present at
+runtime, so importing fiona (which loads libgdal) fails with
+undefined symbol: sqlite3_total_changes64 (a symbol added in SQLite 3.37).
+
+This is the same class of bug as `pandas_to_sql` (an outdated libsqlite3), but surfaces
+through the GDAL stack. Real pipelines hit it via
+`from openhexa.toolbox.iaso import dataframe`, which imports fiona at module load time.
+"""
+
+# Import at module level so the failure surfaces during pipeline import, exactly as it
+# does in a real pipeline (`from openhexa.toolbox.iaso import dataframe` -> `import fiona`).
+import fiona  # noqa: F401
+from openhexa.sdk import current_run, pipeline
+
+
+@pipeline("fiona_import")
+def fiona_import():
+    check_fiona()
+
+
+@fiona_import.task
+def check_fiona():
+    current_run.log_info(f"fiona imported successfully (version {fiona.__version__})")
+
+
+if __name__ == "__main__":
+    fiona_import()

--- a/tests/pipelines/fiona_import/workspace.yaml
+++ b/tests/pipelines/fiona_import/workspace.yaml
@@ -1,0 +1,8 @@
+database:
+  host: localhost
+  username: some_username
+  password: some_password
+  dbname: the_db_name
+  port: 5432
+files:
+  path: ./workspace

--- a/tests/pipelines/pandas_to_sql/pipeline.py
+++ b/tests/pipelines/pandas_to_sql/pipeline.py
@@ -1,0 +1,35 @@
+"""Regression test: `pandas.DataFrame.to_sql` must not crash on import of the sqlite3 module.
+
+    File ".../pandas/io/sql.py", line 897, in pandasSQL_builder
+        import sqlite3
+    ...
+    ImportError: .../_sqlite3.cpython-313-x86_64-linux-gnu.so:
+        undefined symbol: sqlite3_deserialize
+
+The conda Python 3.13 _sqlite3 extension (_sqlite3.cpython-313-x86_64-linux-gnu.so) was linked against a newer libsqlite3 than the one present at runtime, so import sqlite3 fails with undefined symbol: sqlite3_deserialize (a symbol added in SQLite 3.23).
+"""
+
+import pandas as pd
+from openhexa.sdk import current_run, pipeline
+from sqlalchemy import create_engine
+
+
+@pipeline("pandas_to_sql")
+def pandas_to_sql():
+    write_to_sql()
+
+
+@pandas_to_sql.task
+def write_to_sql():
+    current_run.log_info("Writing DataFrame via to_sql...")
+    # In-memory SQLite engine keeps the repro hermetic (no external Postgres).
+    # A real pipeline will probably use a Postgres engine and fail one frame later, but
+    # the root cause is identical: importing sqlite3 / _sqlite3 at runtime.
+    engine = create_engine("sqlite://")
+    df = pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+    df.to_sql("vaccine_forma_clean", if_exists="replace", con=engine)
+    current_run.log_info("to_sql succeeded")
+
+
+if __name__ == "__main__":
+    pandas_to_sql()

--- a/tests/pipelines/pandas_to_sql/workspace.yaml
+++ b/tests/pipelines/pandas_to_sql/workspace.yaml
@@ -1,0 +1,8 @@
+database:
+  host: localhost
+  username: some_username
+  password: some_password
+  dbname: the_db_name
+  port: 5432
+files:
+  path: ./workspace

--- a/tests/test_local_pipelines.py
+++ b/tests/test_local_pipelines.py
@@ -24,3 +24,10 @@ def test_pandas_to_sql_success(docker_image):
 
     assert "undefined symbol: sqlite3_deserialize" not in logs
     assert "to_sql succeeded" in logs
+
+
+def test_fiona_import_success(docker_image):
+    logs = run_local_pipeline(docker_image, pipelines_dir / "fiona_import")
+
+    assert "undefined symbol: sqlite3_total_changes64" not in logs
+    assert "fiona imported successfully" in logs

--- a/tests/test_local_pipelines.py
+++ b/tests/test_local_pipelines.py
@@ -17,3 +17,10 @@ def test_multiply_by_two_success(docker_image):
     )
     assert "Multiplying by two..." in logs
     assert "43 * 2 = 86" in logs
+
+
+def test_pandas_to_sql_success(docker_image):
+    logs = run_local_pipeline(docker_image, pipelines_dir / "pandas_to_sql")
+
+    assert "undefined symbol: sqlite3_deserialize" not in logs
+    assert "to_sql succeeded" in logs


### PR DESCRIPTION
**Changes to the `blsq` docker image:**
- Pin a modern `sqlite` version to avoid some package dragging down the version.
   - **Note: I consider this a temp fix. We'll upgrade to R 4.5 on the `blsq` image soon, and this should fix the issue as well.**

**Changes to the `blsq-r` docker image:** (mostly same as https://github.com/BLSQ/openhexa-docker-images/pull/142)
- Swap conda for the more memory-efficient mamba (like we already did for the other images).
- Update R to `4.5` to match the base image Python stack (pyarrow, libmamba/conda)
- Remove obsolete packages `r-rgeos` and `r-maptools`: both were retired from CRAN in 2023 and have no R `4.5` build on conda-forge (their functionality is served by sf and raster)
- Remove all packages that are directly imported by existing bigger packages (e.g. `tidyverse` imports a ton of them)
- Remove most version pins to let the resolver handle the dependency resolution
- **New:** add 4 new R packages to blsq-r image: `reticulate`, `fpp3`, `survey` and `DHS.rates`. Context: requested for SNT since a long time https://bluesquare.atlassian.net/browse/SNT25-413, but **I also suspect it will change the slow loading of their install script. To be confirmed on demo with `latest-unstable` after merge.**

**Unit tests added:** [HEXA-1684](https://bluesquare.atlassian.net/browse/HEXA-1684)
- Add 2 unit tests related to errors when calling `pandas.to_sql()`, reproducing actual prod errors observed last Friday.

**Other changes:**
- Add a Makefile to more easily build and test images locally (running `make ci` imitates the GitHub action)
- Add a missing test for the `blsq-r` image (old oversight it seems)
- Add a `AGENTS.md` file

[HEXA-1684]: https://bluesquare.atlassian.net/browse/HEXA-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ